### PR TITLE
Allow hbbft to proceed to the next round, with protocol extensions

### DIFF
--- a/test/hbbft_SUITE.erl
+++ b/test/hbbft_SUITE.erl
@@ -1,0 +1,57 @@
+-module(hbbft_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+
+-export([all/0, init_per_testcase/2, end_per_testcase/2]).
+-export([simple_test/1]).
+
+all() ->
+    [simple_test].
+
+init_per_testcase(_, Config) ->
+    Config.
+
+end_per_testcase(_, _) ->
+    ok.
+
+simple_test(_Config) ->
+    N=5,
+    F=(N div 3),
+    dealer:start_link(N, F+1, 'SS512'),
+    {ok, PubKey, PrivateKeys} = dealer:deal(),
+    gen_server:stop(dealer),
+    Workers = [ element(2, hbbft_worker:start_link(N, F, I, SK)) || {I, SK} <- enumerate(PrivateKeys) ],
+    Msgs = [ crypto:strong_rand_bytes(128) || _ <- lists:seq(1, N*20)],
+    %% feed the badgers some msgs
+    lists:foreach(fun(Msg) ->
+                          Destinations = random_n(rand:uniform(N), Workers),
+                          io:format("destinations ~p~n", [Destinations]),
+                          [ok = hbbft_worker:submit_transaction(Msg, D) || D <- Destinations]
+                  end, Msgs),
+    timer:sleep(15000),
+    Chains = sets:from_list(lists:map(fun(W) ->
+                                                {ok, Blocks} = hbbft_worker:get_blocks(W),
+                                                Blocks
+                                        end, Workers)),
+    1 = sets:size(Chains),
+    [Chain] = sets:to_list(Chains),
+    io:format("chain is of height ~p~n", [length(Chain)]),
+    %% verify they are cryptographically linked
+    hbbft_worker:verify_chain(Chain, PubKey),
+    %% check all the transactions are unique
+    BlockTxns = lists:flatten([ hbbft_worker:block_transactions(B) || B <- Chain ]),
+    true = length(BlockTxns) == sets:size(sets:from_list(BlockTxns)),
+    %% check they're all members of the original message list
+    true = sets:is_subset(sets:from_list(BlockTxns), sets:from_list(Msgs)),
+    io:format("chain contains ~p distinct transactions~n", [length(BlockTxns)]),
+    ok.
+
+enumerate(List) ->
+    lists:zip(lists:seq(0, length(List) - 1), List).
+
+random_n(N, List) ->
+    lists:sublist(shuffle(List), N).
+
+shuffle(List) ->
+    [X || {_,X} <- lists:sort([{rand:uniform(), N} || N <- List])].
+

--- a/test/hbbft_worker.erl
+++ b/test/hbbft_worker.erl
@@ -1,0 +1,117 @@
+-module(hbbft_worker).
+
+-behaviour(gen_server).
+
+-export([start_link/4, submit_transaction/2, get_blocks/1]).
+-export([verify_chain/2, block_transactions/1]).
+
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
+
+-record(block, {
+          prev_hash,
+          transactions,
+          signature
+         }).
+
+-record(state, {
+         n,
+         id,
+         hbbft,
+         blocks
+        }).
+
+start_link(N, F, ID, SK) ->
+    gen_server:start_link({local, name(ID)}, ?MODULE, [N, F, ID, SK], []).
+
+submit_transaction(Msg, Pid) ->
+    gen_server:call(Pid, {submit_txn, Msg}, infinity).
+
+get_blocks(Pid) ->
+    gen_server:call(Pid, get_blocks, infinity).
+
+verify_chain([G], PubKey) ->
+    io:format("verifying genesis block~n"),
+    %% genesis block has no prev hash
+    true = G#block.prev_hash == <<>>,
+    %% genesis block should have a valid signature
+    HM = tpke_pubkey:hash_message(PubKey, term_to_binary(G#block{signature= <<>>})),
+    Ugh = tpke_pubkey:hash_message(PubKey, <<"ugh">>),
+    Signature = erlang_pbc:binary_to_element(Ugh, G#block.signature),
+    true = tpke_pubkey:verify_signature(PubKey, Signature, HM);
+verify_chain([A, B|_]=Chain, PubKey) ->
+    io:format("Chain verification depth ~p~n", [length(Chain)]),
+    %% A should have the the prev_hash of B
+    true = A#block.prev_hash == hash_block(B),
+    %% A should have a valid signature
+    HM = tpke_pubkey:hash_message(PubKey, term_to_binary(A#block{signature= <<>>})),
+    Ugh = tpke_pubkey:hash_message(PubKey, <<"ugh">>),
+    Signature = erlang_pbc:binary_to_element(Ugh, A#block.signature),
+    true = tpke_pubkey:verify_signature(PubKey, Signature, HM),
+    verify_chain(tl(Chain), PubKey).
+
+block_transactions(Block) ->
+    Block#block.transactions.
+
+init([N, F, ID, SK]) ->
+    HBBFT = hbbft:init(SK, N, F, ID),
+    {ok, #state{hbbft=HBBFT, blocks=[], id=ID, n=N}}.
+
+handle_call({submit_txn, Txn}, _From, State = #state{hbbft=HBBFT}) ->
+    NewState = dispatch(hbbft:input(HBBFT, Txn), State),
+    {reply, ok, NewState};
+handle_call(get_blocks, _From, State) ->
+    {reply, {ok, State#state.blocks}, State};
+handle_call(Msg, _From, State) ->
+    io:format("unhandled msg ~p~n", [Msg]),
+    {reply, ok, State}.
+
+handle_cast({hbbft, PeerID, Msg}, State = #state{hbbft=HBBFT}) ->
+    NewState = dispatch(hbbft:handle_msg(HBBFT, PeerID, Msg), State),
+    {noreply, NewState};
+handle_cast(Msg, State) ->
+    io:format("unhandled msg ~p~n", [Msg]),
+    {noreply, State}.
+
+handle_info(Msg, State) ->
+    io:format("unhandled msg ~p~n", [Msg]),
+    {noreply, State}.
+
+dispatch({NewHBBFT, {send, ToSend}}, State) ->
+    do_send(ToSend, State),
+    State#state{hbbft=NewHBBFT};
+dispatch({NewHBBFT, {result, {transactions, Txns}}}, State) ->
+    NewBlock = case State#state.blocks of
+                   [] ->
+                       %% genesis block
+                       #block{prev_hash= <<>>, transactions=Txns, signature= <<>>};
+                   [PrevBlock|_Blocks] ->
+                       #block{prev_hash=hash_block(PrevBlock), transactions=Txns, signature= <<>>}
+               end,
+    %% tell the badger to finish the round
+    dispatch(hbbft:finalize_round(NewHBBFT, Txns, term_to_binary(NewBlock)), State#state{blocks=[NewBlock|State#state.blocks]});
+dispatch({NewHBBFT, {result, {signature, Sig}}}, State = #state{blocks=[NewBlock|Blocks]}) ->
+    dispatch(hbbft:next_round(NewHBBFT), State#state{blocks=[NewBlock#block{signature=Sig}|Blocks]});
+dispatch({NewHBBFT, ok}, State) ->
+    State#state{hbbft=NewHBBFT};
+dispatch({NewHBBFT, Other}, State) ->
+    io:format("UNHANDLED ~p~n", [Other]),
+    State#state{hbbft=NewHBBFT};
+dispatch(Other, State) ->
+    io:format("UNHANDLED2 ~p~n", [Other]),
+    State.
+
+
+do_send([], _) ->
+    ok;
+do_send([{unicast, Dest, Msg}|T], State) ->
+    gen_server:cast(name(Dest), {hbbft, State#state.id, Msg}),
+    do_send(T, State);
+do_send([{multicast, Msg}|T], State) ->
+    [ gen_server:cast(name(Dest), {hbbft, State#state.id, Msg}) || Dest <- lists:seq(0, State#state.n - 1)],
+    do_send(T, State).
+
+name(N) ->
+    list_to_atom(lists:flatten(io_lib:format("hbbft_worker_~b", [N]))).
+
+hash_block(Block) ->
+    crypto:hash(sha256, term_to_binary(Block)).


### PR DESCRIPTION
The HoneyBadgerBFT paper is a bit light on the details of how it moves
to the next round. Indeed, the paper assumes transactions are filtered,
reordered or retained in the buffer via some undefined mechanism.

This commit implements a mechanism to do that, as well as a mechanism
for proving f+1 nodes all agreed on this block.

When a set of transactions has been agreed on, the hbbft protocol
returns `{result, {transactions, [binary()]}}`. The application then has
an opportunity to filter/reorder/retain any transactions it chooses. It
then calls finalize_round/3 with the set of transactions it wants the
protocol to *delete* from its buffer as well as a binary representing
the block over which it wants a threshold signature.

The protocol removes the listed transactions from its buffer and then
goes about trying to obtain a signature over the block. Assuming f+1
other nodes also performed the same block construction, a threshold
signature can be obtained and the block can be shown to have majority
agreement.