### PR TITLE
Make things about 4 times faster with some simple tweaks

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -1,7 +1,7 @@
 {"1.1.0",
 [{<<"erl_tpke">>,
   {git,"https://github.com/helium/erlang_tpke.git",
-       {ref,"744f6a26da55b71a2b0d262c5addb08d8e921131"}},
+       {ref,"21f760b85d4954624b5b89f9f1e1d5180b4501d5"}},
   0},
  {<<"erlang_pbc">>,
   {git,"https://github.com/helium/erlang_pbc.git",

--- a/src/hbbft.erl
+++ b/src/hbbft.erl
@@ -78,7 +78,7 @@ handle_msg(Data = #data{round=R}, J, {dec, R, I, Share}) ->
     NewShares = maps:put({I, J}, Share, Data#data.dec_shares),
     %% check if we have enough to decode the bundle
     SharesForThisBundle = [ S || {{Idx, _}, S} <- maps:to_list(NewShares), I == Idx],
-    case length(SharesForThisBundle) > Data#data.f of
+    case length(SharesForThisBundle) > Data#data.f andalso not maps:is_key({I, J}, Data#data.dec_shares) of
         true ->
             io:format("~p got enough shares to decrypt bundle ~n", [Data#data.j]),
             {I, Enc} = lists:keyfind(I, 1, Data#data.acs_results),
@@ -163,9 +163,7 @@ share_to_binary({ShareIdx, ShareElement}) ->
     <<ShareIdx:8/integer-unsigned, ShareBinary/binary>>.
 
 binary_to_share(<<ShareIdx:8/integer-unsigned, ShareBinary/binary>>, SK) ->
-    %% XXX we don't have a great way to deserialize the elements yet, this is a hack
-    Ugh = tpke_pubkey:hash_message(tpke_privkey:public_key(SK), <<"ugh">>),
-    ShareElement = erlang_pbc:binary_to_element(Ugh, ShareBinary),
+    ShareElement = tpke_pubkey:deserialize_element(tpke_privkey:public_key(SK), ShareBinary),
     {ShareIdx, ShareElement}.
 
 %% wrap a subprotocol's outbound messages with a protocol identifier
@@ -196,10 +194,8 @@ encrypt(PK, Bin) ->
 
 get_encrypted_key(SK, <<_IV:16/binary, EncKeySize:16/integer-unsigned, EncKey:EncKeySize/binary, _/binary>>) ->
     <<USize:8/integer-unsigned, UBin:USize/binary, V:32/binary, WSize:8/integer-unsigned, WBin:WSize/binary>> = EncKey,
-    %% XXX we don't have a great way to deserialize the elements yet, this is a hack
-    Ugh = tpke_pubkey:hash_message(tpke_privkey:public_key(SK), <<"ugh">>),
-    U = erlang_pbc:binary_to_element(Ugh, UBin),
-    W = erlang_pbc:binary_to_element(Ugh, WBin),
+    U = tpke_pubkey:deserialize_element(tpke_privkey:public_key(SK), UBin),
+    W = tpke_pubkey:deserialize_element(tpke_privkey:public_key(SK), WBin),
     {U, V, W}.
 
 decrypt(Key, Bin) ->
@@ -280,9 +276,7 @@ hbbft_init_test_() ->
                            %?assertEqual(N, sets:size(ConvergedResults2)),
                            DistinctResults2 = sets:from_list([BVal || {result, {_, BVal}} <- sets:to_list(ConvergedResults2)]),
                            [{signature, Sig}] = sets:to_list(DistinctResults2),
-                           %% XXX we don't have a great way to deserialize the elements yet, this is a hack
-                           Ugh = tpke_pubkey:hash_message(PubKey, <<"ugh">>),
-                           Signature = erlang_pbc:binary_to_element(Ugh, Sig),
+                           Signature = tpke_pubkey:deserialize_element(PubKey, Sig),
                            %% everyone should have converged to the same signature
                            ?assertEqual(1, sets:size(DistinctResults)),
                            HM = tpke_pubkey:hash_message(PubKey, Block),

--- a/src/hbbft.erl
+++ b/src/hbbft.erl
@@ -194,8 +194,9 @@ encrypt(PK, Bin) ->
 
 get_encrypted_key(SK, <<_IV:16/binary, EncKeySize:16/integer-unsigned, EncKey:EncKeySize/binary, _/binary>>) ->
     <<USize:8/integer-unsigned, UBin:USize/binary, V:32/binary, WSize:8/integer-unsigned, WBin:WSize/binary>> = EncKey,
-    U = tpke_pubkey:deserialize_element(tpke_privkey:public_key(SK), UBin),
-    W = tpke_pubkey:deserialize_element(tpke_privkey:public_key(SK), WBin),
+    PubKey = tpke_privkey:public_key(SK),
+    U = tpke_pubkey:deserialize_element(PubKey, UBin),
+    W = tpke_pubkey:deserialize_element(PubKey, WBin),
     {U, V, W}.
 
 decrypt(Key, Bin) ->

--- a/test/hbbft_worker.erl
+++ b/test/hbbft_worker.erl
@@ -35,8 +35,7 @@ verify_chain([G], PubKey) ->
     true = G#block.prev_hash == <<>>,
     %% genesis block should have a valid signature
     HM = tpke_pubkey:hash_message(PubKey, term_to_binary(G#block{signature= <<>>})),
-    Ugh = tpke_pubkey:hash_message(PubKey, <<"ugh">>),
-    Signature = erlang_pbc:binary_to_element(Ugh, G#block.signature),
+    Signature = tpke_pubkey:deserialize_element(PubKey, G#block.signature),
     true = tpke_pubkey:verify_signature(PubKey, Signature, HM);
 verify_chain([A, B|_]=Chain, PubKey) ->
     io:format("Chain verification depth ~p~n", [length(Chain)]),
@@ -44,8 +43,7 @@ verify_chain([A, B|_]=Chain, PubKey) ->
     true = A#block.prev_hash == hash_block(B),
     %% A should have a valid signature
     HM = tpke_pubkey:hash_message(PubKey, term_to_binary(A#block{signature= <<>>})),
-    Ugh = tpke_pubkey:hash_message(PubKey, <<"ugh">>),
-    Signature = erlang_pbc:binary_to_element(Ugh, A#block.signature),
+    Signature = tpke_pubkey:deserialize_element(PubKey, A#block.signature),
     true = tpke_pubkey:verify_signature(PubKey, Signature, HM),
     verify_chain(tl(Chain), PubKey).
 


### PR DESCRIPTION
This just fixes some very obvious performance issues discovered with
profiling:

* Fix element deserialization to use a new TPKE function
* Don't "double process" messages that require expensive TPKE calls

Before:
![profile-before](https://user-images.githubusercontent.com/86412/38693509-efa4c506-3e3b-11e8-92da-476cf3cbfdcc.png)

After:
![profile-after](https://user-images.githubusercontent.com/86412/38693514-f309bac6-3e3b-11e8-970f-fe95db7e90d2.png)
