### PR TITLE
Address bugs in BBA protocol's use of common coin

### DIFF
--- a/src/hbbft_bba.erl
+++ b/src/hbbft_bba.erl
@@ -158,8 +158,8 @@ bval(Data=#bba_data{n=N, f=F}, Id, V) ->
                             %% TODO need more entropy for the SID
                             {CoinData, {send, CoinSend}} = hbbft_cc:get_coin(hbbft_cc:init(NewData3#bba_data.secret_key, term_to_binary({NewData3#bba_data.round}), N, F)),
                             {NewData3#bba_data{coin=CoinData}, {send, hbbft_utils:wrap({coin, Data#bba_data.round}, CoinSend) ++ ToSend2}};
-                        false ->
-                            {NewData3, ToSend2}
+                        _ ->
+                            {NewData3, {send, ToSend2}}
                     end;
                 false ->
                     {NewData3, {send, ToSend2}}

--- a/src/hbbft_bba.erl
+++ b/src/hbbft_bba.erl
@@ -454,4 +454,28 @@ two_dead_test() ->
     %% should not converge
     ?assertEqual(0, sets:size(ConvergedResults)),
     ok.
+
+%% https://github.com/amiller/HoneyBadgerBFT/issues/59
+%% constructive_attack_test_() ->
+%%     {timeout, 60, fun() ->
+%%                           N = 7,
+%%                           F = 2,
+%%                           dealer:start_link(N, F+1, 'SS512'),
+%%                           {ok, _PubKey, PrivateKeys} = dealer:deal(),
+%%                           gen_server:stop(dealer),
+%%                           States = [hbbft_bba:init(Sk, N, F) || Sk <- PrivateKeys],
+%%                           StatesWithId = lists:zip(lists:seq(0, length(States) - 1), States),
+%%                           MixedList = lists:zip([1, 1, 1, 1, 0, 0, 0], StatesWithId),
+%%                           %% all valid members should call get_coin
+%%                           Res = lists:map(fun({I, {J, State}}) ->
+%%                                                   {NewState, Result} = input(State, I),
+%%                                                   {{J, NewState}, {J, Result}}
+%%                                           end, MixedList),
+%%                           {NewStates, Results} = lists:unzip(Res),
+%%                           {_, ConvergedResults} = hbbft_test_utils:do_send_outer(?MODULE, Results, NewStates, sets:new()),
+%%                           DistinctResults = sets:from_list([BVal || {result, {_, BVal}} <- sets:to_list(ConvergedResults)]),
+%%                           ?assertEqual(N, sets:size(ConvergedResults)),
+%%                           ?assertEqual(1, sets:size(DistinctResults)),
+%%                           ok
+%%                   end}.
 -endif.

--- a/src/hbbft_bba.erl
+++ b/src/hbbft_bba.erl
@@ -152,7 +152,7 @@ bval(Data=#bba_data{n=N, f=F}, Id, V) ->
             case threshold(N, F, NewData3, aux) of
                 true ->
                     %% check if we have n-f conf messages
-                    case threshold(F, F, NewData3, conf) of
+                    case threshold(N, F, NewData3, conf) of
                         %% instantiate the common coin
                         true when NewData3#bba_data.coin == undefined ->
                             %% TODO need more entropy for the SID


### PR DESCRIPTION
Original issue reported in the python implementation of HoneyBadgerBFT: https://github.com/amiller/HoneyBadgerBFT/issues/59

* Add conf message round
* Track bval messages broadcasted in each round
* Add another test for ensuring that BBA terminates
* Allow peers to send both 0 and 1 in the same round and track it in the witness