### PR TITLE
Attempt to fix bug where ACS does not complete

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -21,7 +21,7 @@
 {profiles, [
             {test, [
                {deps, [
-                       {relcast, ".*", {git, "https://github.com/helium/relcast.git", {branch, "madninja/review"}}}
+                       {relcast, ".*", {git, "https://github.com/helium/relcast.git", {branch, "master"}}}
                       ]}
               ]}
            ]}.

--- a/src/hbbft_cc.erl
+++ b/src/hbbft_cc.erl
@@ -52,8 +52,8 @@ init(SecretKeyShard, Sid, N, F) ->
 %% Figure12. Bullet2
 %% on input GetCoin, multicast ThresholdSignpk (ski, sid)
 -spec get_coin(cc_data()) -> {cc_data(), ok | {send, [hbbft_utils:multicast(share_msg())]}}.
-get_coin(#cc_data{state=done}) ->
-    ignore;
+get_coin(Data = #cc_data{state=done}) ->
+    {Data, ok};
 get_coin(Data) ->
     Share = tpke_privkey:sign(Data#cc_data.sk, Data#cc_data.sid),
     SerializedShare = hbbft_utils:share_to_binary(Share),
@@ -70,7 +70,7 @@ handle_msg(Data, J, {share, Share}) ->
     share(Data, J, Share).
 
 %% TODO: more specific return type than an integer?
--spec share(cc_data(), non_neg_integer(), binary()) -> {cc_data(), ok | {result, integer()}}.
+-spec share(cc_data(), non_neg_integer(), binary()) -> {cc_data(), ok | {result, integer()}} | ignore.
 share(#cc_data{state=done}, _J, _Share) ->
     ignore;
 share(Data, J, Share) ->


### PR DESCRIPTION
A late-finishing RBC for which the corresponding BBA has already completed may be the final message needed for ACS to complete. Thus, add a completion check to that branch of the code handling RBC messages.