### PR TITLE
Allow ACS to return a result and messages to send simultaneously

### DIFF
--- a/src/hbbft.erl
+++ b/src/hbbft.erl
@@ -191,7 +191,7 @@ handle_msg(Data = #hbbft_data{round=R}, J, {{acs, R}, ACSMsg}) ->
             {Data#hbbft_data{acs=NewACS}, ok};
         {NewACS, {send, ACSResponse}} ->
             {Data#hbbft_data{acs=NewACS}, {send, hbbft_utils:wrap({acs, Data#hbbft_data.round}, ACSResponse)}};
-        {NewACS, {result, Results}} ->
+        {NewACS, {result_and_send, Results, {send, ACSResponse}}} ->
             %% ACS[r] has returned, time to move on to the decrypt phase
             %% start decrypt phase
             Replies = lists:map(fun({I, Result}) ->
@@ -200,7 +200,7 @@ handle_msg(Data = #hbbft_data{round=R}, J, {{acs, R}, ACSMsg}) ->
                                         SerializedShare = hbbft_utils:share_to_binary(Share),
                                         {multicast, {dec, Data#hbbft_data.round, I, SerializedShare}}
                                 end, Results),
-            {Data#hbbft_data{acs=NewACS, acs_results=Results}, {send, Replies}};
+            {Data#hbbft_data{acs=NewACS, acs_results=Results}, {send,  hbbft_utils:wrap({acs, Data#hbbft_data.round}, ACSResponse) ++ Replies}};
         {NewACS, defer} ->
             {Data#hbbft_data{acs=NewACS}, defer}
     end;


### PR DESCRIPTION
After observing cases where all the required BBA and ACS instances
completed, but ACS itself did not return. I believe this is caused by
the final BBA completing, returning the final 1 that puts us over the
N-F threshold. However, the current code path assumes that the final BBA
won't be the final one to return 1, and also assumes that ACS can send a
message, or return a result, but not both.

This change allows ACS to return a result AND send messages, and updates
HBBFT itself to handle that return value. This along with the prior
change to ACS to check for a return in the RBC handling code, should
catch the missing termination conditions.