### PR TITLE
More consensus fixes to ACS

### DIFF
--- a/src/hbbft_acs.erl
+++ b/src/hbbft_acs.erl
@@ -112,8 +112,7 @@ handle_msg(Data, J, {{rbc, I}, RBCMsg}) ->
                             %% this BBA probably already completed, check if ACS has completed
                             check_completion(store_bba_state(NewData, I, DoneBBA), []);
                         {NewBBA, {send, ToSend}} ->
-                            {store_bba_input(store_bba_state(NewData, I, NewBBA), I, 1),
-                            {send, hbbft_utils:wrap({bba, I}, ToSend)}}
+                            check_completion(store_bba_input(store_bba_state(NewData, I, NewBBA), I, 1), hbbft_utils:wrap({bba, I}, ToSend))
                     end
             end;
         {NewRBC, ok} ->

--- a/src/hbbft_acs.erl
+++ b/src/hbbft_acs.erl
@@ -110,7 +110,7 @@ handle_msg(Data, J, {{rbc, I}, RBCMsg}) ->
                     case hbbft_bba:input(BBA#bba_state.bba_data, 1) of
                         {DoneBBA, ok} ->
                             %% this BBA probably already completed, check if ACS has completed
-                            check_completion(store_bba_state(NewData, I, DoneBBA), []);
+                            check_completion(store_bba_input(store_bba_state(NewData, I, DoneBBA), I, 1), []);
                         {NewBBA, {send, ToSend}} ->
                             check_completion(store_bba_input(store_bba_state(NewData, I, NewBBA), I, 1), hbbft_utils:wrap({bba, I}, ToSend))
                     end
@@ -140,7 +140,7 @@ handle_msg(Data = #acs_data{n=N, f=F}, J, {{bba, I}, BBAMsg}) ->
                                                                           {FailedBBA, {send, ToSend}} ->
                                                                               {store_bba_input(store_bba_state(DataAcc, E, FailedBBA), E, 0), [hbbft_utils:wrap({bba, E}, ToSend)|MsgAcc]};
                                                                           {DoneBBA, ok} ->
-                                                                              {store_bba_state(DataAcc, E, DoneBBA), MsgAcc}
+                                                                              {store_bba_input(store_bba_state(DataAcc, E, DoneBBA), E, 0), MsgAcc}
                                                                       end;
                                                                   true ->
                                                                       Acc


### PR DESCRIPTION
This PR adds another completion check for ACS and it ensures we track we provided an input to a BBA even if that BBA was already completed.

In testing conditions it seems to resolve the intermittent consensus failure we've been tracking.