### PR TITLE
Handle decryption of ACS results failing

### DIFF
--- a/src/hbbft.erl
+++ b/src/hbbft.erl
@@ -220,7 +220,7 @@ handle_msg(Data = #hbbft_data{round=R}, J, {dec, R, I, Share}) ->
             EncKey = get_encrypted_key(Data#hbbft_data.secret_key, Enc),
             case combine_shares(Data#hbbft_data.f, Data#hbbft_data.secret_key, SharesForThisBundle, EncKey) of
                 undefined ->
-                    %% can't recover the key, consider this ACS failed if we have 2f+1 shares and still can't decrypt
+                    %% can't recover the key, consider this ACS failed if we have 2f+1 shares and still can't recover the key
                     case length(SharesForThisBundle) > 2 * Data#hbbft_data.f of
                         true ->
                             %% ok, just declare this ACS returned an empty list
@@ -479,7 +479,7 @@ check_completion(Data) ->
 -spec combine_shares(pos_integer(), tpke_privkey:privkey(), [tpke_privkey:share()], tpke_pubkey:ciphertext()) -> undefined | binary().
 combine_shares(F, SK, SharesForThisBundle, EncKey) ->
     %% filter the shares with verify_share/3
-    %% only use valid shares so a invalid share doesn't corrupt our result
+    %% only use valid shares so an invalid share doesn't corrupt our result
     ValidSharesForThisBundle = [ S || S <- SharesForThisBundle, tpke_pubkey:verify_share(tpke_privkey:public_key(SK), S, EncKey) ],
     case length(ValidSharesForThisBundle) > F of
         true ->

--- a/src/hbbft.erl
+++ b/src/hbbft.erl
@@ -232,15 +232,12 @@ handle_msg(Data = #hbbft_data{round=R}, J, {dec, R, I, Share}) ->
                 DecKey ->
                     case decrypt(DecKey, Enc) of
                         error ->
-                            %% can't decrypt, also consider this ACS a failure if we have 2f+1 shares but still can't decrypt
-                            case length(SharesForThisBundle) > 2 * Data#hbbft_data.f of
-                                true ->
-                                    %% ok, just declare this ACS returned an empty list
-                                    NewDecrypted = maps:put(I, [], Data#hbbft_data.decrypted),
-                                    check_completion(Data#hbbft_data{dec_shares=NewShares, decrypted=NewDecrypted});
-                                false ->
-                                    {Data#hbbft_data{dec_shares=NewShares}, ok}
-                            end;
+                            %% can't decrypt, consider this ACS a failure
+                            %% just declare this ACS returned an empty list because we had
+                            %% f+1 valid shares but the resulting decryption key was unusuable to decrypt
+                            %% the transaction bundle
+                            NewDecrypted = maps:put(I, [], Data#hbbft_data.decrypted),
+                            check_completion(Data#hbbft_data{dec_shares=NewShares, decrypted=NewDecrypted});
                         Decrypted ->
                             {Stamp, Transactions} = binary_to_term(Decrypted),
                             NewDecrypted = maps:put(I, Transactions, Data#hbbft_data.decrypted),

--- a/test/hbbft_SUITE.erl
+++ b/test/hbbft_SUITE.erl
@@ -11,7 +11,8 @@
          one_actor_missing_test/1,
          two_actors_missing_test/1,
          encrypt_decrypt_test/1,
-         start_on_demand_test/1
+         start_on_demand_test/1,
+         one_actor_wrong_key_test/1
         ]).
 
 all() ->
@@ -22,7 +23,8 @@ all() ->
      one_actor_missing_test,
      two_actors_missing_test,
      encrypt_decrypt_test,
-     start_on_demand_test
+     start_on_demand_test,
+     one_actor_wrong_key_test
     ].
 
 init_per_testcase(_, Config) ->
@@ -273,6 +275,58 @@ start_on_demand_test(Config) ->
     true = sets:is_subset(sets:from_list(BlockTxns), sets:from_list([KnownMsg | Msgs])),
     io:format("chain contains ~p distinct transactions~n", [length(BlockTxns)]),
     ok.
+
+one_actor_wrong_key_test(Config) ->
+    N = proplists:get_value(n, Config),
+    F = proplists:get_value(f, Config),
+    BatchSize = proplists:get_value(batchsize, Config),
+    PubKey = proplists:get_value(pubkey, Config),
+    PrivateKeys0 = proplists:get_value(privatekeys, Config),
+    {ok, Dealer} = dealer:new(N, F+1, 'SS512'),
+    {ok, {_PubKey, PrivateKeys1}} = dealer:deal(Dealer),
+    PrivateKeys = [hd(PrivateKeys1)|tl(PrivateKeys0)],
+
+    ct:pal("Private keys ~p", [PrivateKeys]),
+    Workers = [ element(2, hbbft_worker:start_link(N, F, I, tpke_privkey:serialize(SK), BatchSize, false)) || {I, SK} <- enumerate(PrivateKeys) ],
+    Msgs = [ crypto:strong_rand_bytes(128) || _ <- lists:seq(1, N*20)],
+    %% feed the badgers some msgs
+    lists:foreach(fun(Msg) ->
+                          Destinations = random_n(rand:uniform(N), Workers),
+                          io:format("destinations ~p~n", [Destinations]),
+                          [ok = hbbft_worker:submit_transaction(Msg, D) || D <- Destinations]
+                  end, Msgs),
+
+    %% wait for all the worker's mailboxes to settle and
+    %% wait for the chains to converge
+    ok = hbbft_ct_utils:wait_until(fun() ->
+                                           Chains = sets:from_list(lists:map(fun(W) ->
+                                                                                     {ok, Blocks} = hbbft_worker:get_blocks(W),
+                                                                                     Blocks
+                                                                             end, tl(Workers))),
+
+                                           0 == lists:sum([element(2, erlang:process_info(W, message_queue_len)) || W <- Workers ]) andalso
+                                           1 == sets:size(Chains) andalso
+                                           0 /= length(hd(sets:to_list(Chains)))
+                                   end, 60*2, 500),
+
+
+    Chains = sets:from_list(lists:map(fun(W) ->
+                                              {ok, Blocks} = hbbft_worker:get_blocks(W),
+                                              Blocks
+                                      end, tl(Workers))),
+    1 = sets:size(Chains),
+    [Chain] = sets:to_list(Chains),
+    io:format("chain is of height ~p~n", [length(Chain)]),
+    %% verify they are cryptographically linked
+    true = hbbft_worker:verify_chain(Chain, PubKey),
+    %% check all the transactions are unique
+    BlockTxns = lists:flatten([ hbbft_worker:block_transactions(B) || B <- Chain ]),
+    true = length(BlockTxns) == sets:size(sets:from_list(BlockTxns)),
+    %% check they're all members of the original message list
+    true = sets:is_subset(sets:from_list(BlockTxns), sets:from_list(Msgs)),
+    io:format("chain contains ~p distinct transactions~n", [length(BlockTxns)]),
+    ok.
+
 
 %% helper functions
 

--- a/test/hbbft_SUITE.erl
+++ b/test/hbbft_SUITE.erl
@@ -12,7 +12,8 @@
          two_actors_missing_test/1,
          encrypt_decrypt_test/1,
          start_on_demand_test/1,
-         one_actor_wrong_key_test/1
+         one_actor_wrong_key_test/1,
+         one_actor_corrupted_key_test/1
         ]).
 
 all() ->
@@ -24,7 +25,8 @@ all() ->
      two_actors_missing_test,
      encrypt_decrypt_test,
      start_on_demand_test,
-     one_actor_wrong_key_test
+     one_actor_wrong_key_test,
+     one_actor_corrupted_key_test
     ].
 
 init_per_testcase(_, Config) ->
@@ -284,9 +286,11 @@ one_actor_wrong_key_test(Config) ->
     PrivateKeys0 = proplists:get_value(privatekeys, Config),
     {ok, Dealer} = dealer:new(N, F+1, 'SS512'),
     {ok, {_PubKey, PrivateKeys1}} = dealer:deal(Dealer),
+    %% give actor 1 a completely unrelated key
+    %% this will prevent it from doing any valid threshold cryptography
+    %% and thus it will not be able to reach consensus
     PrivateKeys = [hd(PrivateKeys1)|tl(PrivateKeys0)],
 
-    ct:pal("Private keys ~p", [PrivateKeys]),
     Workers = [ element(2, hbbft_worker:start_link(N, F, I, tpke_privkey:serialize(SK), BatchSize, false)) || {I, SK} <- enumerate(PrivateKeys) ],
     Msgs = [ crypto:strong_rand_bytes(128) || _ <- lists:seq(1, N*20)],
     %% feed the badgers some msgs
@@ -327,6 +331,59 @@ one_actor_wrong_key_test(Config) ->
     io:format("chain contains ~p distinct transactions~n", [length(BlockTxns)]),
     ok.
 
+one_actor_corrupted_key_test(Config) ->
+    N = proplists:get_value(n, Config),
+    F = proplists:get_value(f, Config),
+    BatchSize = proplists:get_value(batchsize, Config),
+    PubKey = proplists:get_value(pubkey, Config),
+    [PK1|PrivateKeys0] = proplists:get_value(privatekeys, Config),
+    PKE = element(3, PK1),
+    %% scramble the private element of the key
+    %% this will not prevent the actor for encrypting their bundle
+    %% merely prevent it producing valid decryption shares
+    %% thus all the actors will be able to converge
+    PK2 = setelement(3, PK1, erlang_pbc:element_random(PKE)),
+    PrivateKeys = [PK2|PrivateKeys0],
+
+    Workers = [ element(2, hbbft_worker:start_link(N, F, I, tpke_privkey:serialize(SK), BatchSize, false)) || {I, SK} <- enumerate(PrivateKeys) ],
+    Msgs = [ crypto:strong_rand_bytes(128) || _ <- lists:seq(1, N*20)],
+    %% feed the badgers some msgs
+    lists:foreach(fun(Msg) ->
+                          Destinations = random_n(rand:uniform(N), Workers),
+                          io:format("destinations ~p~n", [Destinations]),
+                          [ok = hbbft_worker:submit_transaction(Msg, D) || D <- Destinations]
+                  end, Msgs),
+
+    %% wait for all the worker's mailboxes to settle and
+    %% wait for the chains to converge
+    ok = hbbft_ct_utils:wait_until(fun() ->
+                                           Chains = sets:from_list(lists:map(fun(W) ->
+                                                                                     {ok, Blocks} = hbbft_worker:get_blocks(W),
+                                                                                     Blocks
+                                                                             end, (Workers))),
+
+                                           0 == lists:sum([element(2, erlang:process_info(W, message_queue_len)) || W <- Workers ]) andalso
+                                           1 == sets:size(Chains) andalso
+                                           0 /= length(hd(sets:to_list(Chains)))
+                                   end, 60*2, 500),
+
+
+    Chains = sets:from_list(lists:map(fun(W) ->
+                                              {ok, Blocks} = hbbft_worker:get_blocks(W),
+                                              Blocks
+                                      end, (Workers))),
+    1 = sets:size(Chains),
+    [Chain] = sets:to_list(Chains),
+    io:format("chain is of height ~p~n", [length(Chain)]),
+    %% verify they are cryptographically linked
+    true = hbbft_worker:verify_chain(Chain, PubKey),
+    %% check all the transactions are unique
+    BlockTxns = lists:flatten([ hbbft_worker:block_transactions(B) || B <- Chain ]),
+    true = length(BlockTxns) == sets:size(sets:from_list(BlockTxns)),
+    %% check they're all members of the original message list
+    true = sets:is_subset(sets:from_list(BlockTxns), sets:from_list(Msgs)),
+    io:format("chain contains ~p distinct transactions~n", [length(BlockTxns)]),
+    ok.
 
 %% helper functions
 


### PR DESCRIPTION
If the transaction bundle produced by an ACS instance results in a
failure to decrypt, return the empty list as the result of that ACS and
continue to checking if enough ACSes have completed and we can return a
list of transactions to the user.