### PR TITLE
Update to new TPKE API for verified ciphertexts

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -13,6 +13,14 @@
     pc
 ]}.
 
+{xref_checks, [
+    undefined_function_calls,
+    undefined_functions,
+    locals_not_used,
+    deprecated_function_calls,
+    deprecated_functions
+]}.
+
 {dialyzer, [
             {warnings, [unknown]},
             {plt_apps, all_deps}

--- a/rebar.lock
+++ b/rebar.lock
@@ -9,7 +9,7 @@
   1},
  {<<"erlang_tpke">>,
   {git,"https://github.com/helium/erlang_tpke.git",
-       {ref,"b1ccd54d6f1763c1e59b03c97e57dcd814af985e"}},
+       {ref,"e784d6352e13db51cbd4d7462477a9980bfe9509"}},
   0},
  {<<"merkerl">>,{pkg,<<"merkerl">>,<<"1.0.1">>},0}]}.
 [

--- a/src/hbbft_cc.erl
+++ b/src/hbbft_cc.erl
@@ -77,7 +77,7 @@ share(Data, J, Share) ->
     case maps:is_key(J, Data#cc_data.shares) of
         false ->
             %% store the deserialized share in the shares map, convenient to use later to verify signature
-            DeserializedShare = hbbft_utils:binary_to_share(Share, Data#cc_data.sk),
+            DeserializedShare = hbbft_utils:binary_to_share(Share, tpke_privkey:public_key(Data#cc_data.sk)),
             case tpke_pubkey:verify_signature_share(tpke_privkey:public_key(Data#cc_data.sk), DeserializedShare, Data#cc_data.sid) of
                 true ->
                     NewData = Data#cc_data{shares=maps:put(J, DeserializedShare, Data#cc_data.shares)},
@@ -121,4 +121,4 @@ serialize_shares(Shares) ->
 
 -spec deserialize_shares(#{non_neg_integer() => binary()}, tpke_privkey:privkey()) -> #{non_neg_integer() => tpke_privkey:share()}.
 deserialize_shares(Shares, SK) ->
-    maps:map(fun(_K, V) -> hbbft_utils:binary_to_share(V, SK) end, Shares).
+    maps:map(fun(_K, V) -> hbbft_utils:binary_to_share(V, tpke_privkey:public_key(SK)) end, Shares).

--- a/src/hbbft_utils.erl
+++ b/src/hbbft_utils.erl
@@ -8,18 +8,14 @@
 -export([share_to_binary/1, binary_to_share/2, wrap/2, random_n/2, shuffle/1]).
 
 -spec share_to_binary(tpke_privkey:share()) -> binary().
-share_to_binary({ShareIdx, '?'}) ->
-    <<ShareIdx:8/integer-unsigned, $?>>;
 share_to_binary({ShareIdx, ShareElement}) ->
     %% Assume less than 256 members in the consensus group
     ShareBinary = erlang_pbc:element_to_binary(ShareElement),
     <<ShareIdx:8/integer-unsigned, ShareBinary/binary>>.
 
--spec binary_to_share(binary(), tpke_privkey:privkey()) -> tpke_privkey:share().
-binary_to_share(<<ShareIdx:8/integer-unsigned, $?>>, _SK) ->
-    {ShareIdx, '?'};
-binary_to_share(<<ShareIdx:8/integer-unsigned, ShareBinary/binary>>, SK) ->
-    ShareElement = tpke_pubkey:deserialize_element(tpke_privkey:public_key(SK), ShareBinary),
+-spec binary_to_share(binary(), tpke_pubkey:pubkey()) -> tpke_privkey:share().
+binary_to_share(<<ShareIdx:8/integer-unsigned, ShareBinary/binary>>, PK) ->
+    ShareElement = tpke_pubkey:deserialize_element(PK, ShareBinary),
     {ShareIdx, ShareElement}.
 
 %% wrap a subprotocol's outbound messages with a protocol identifier

--- a/test/hbbft_SUITE.erl
+++ b/test/hbbft_SUITE.erl
@@ -220,7 +220,7 @@ encrypt_decrypt_test(Config) ->
 
     PlainText = crypto:strong_rand_bytes(24),
     Enc = hbbft:encrypt(PubKey, PlainText),
-    EncKey = hbbft:get_encrypted_key(hd(PrivateKeys), Enc),
+    {ok, EncKey} = hbbft:get_encrypted_key(hd(PrivateKeys), Enc),
     DecKey = tpke_pubkey:combine_shares(PubKey, EncKey, [ tpke_privkey:decrypt_share(SK, EncKey) || SK <- PrivateKeys]),
     ?assertEqual(PlainText, hbbft:decrypt(DecKey, Enc)),
     ok.

--- a/test/hbbft_relcast_SUITE.erl
+++ b/test/hbbft_relcast_SUITE.erl
@@ -235,7 +235,7 @@ encrypt_decrypt_test(Config) ->
 
     PlainText = crypto:strong_rand_bytes(24),
     Enc = hbbft:encrypt(PubKey, PlainText),
-    EncKey = hbbft:get_encrypted_key(hd(PrivateKeys), Enc),
+    {ok, EncKey} = hbbft:get_encrypted_key(hd(PrivateKeys), Enc),
     DecKey = tpke_pubkey:combine_shares(PubKey, EncKey, [ tpke_privkey:decrypt_share(SK, EncKey) || SK <- PrivateKeys]),
     ?assertEqual(PlainText, hbbft:decrypt(DecKey, Enc)),
     ok.


### PR DESCRIPTION
TPKE has been updated to track the validity of the ciphertext inside the
ciphertext value itself and not check it for each invocation of
verify_share/combine_share/decrypt. This means that, to avoid
reverifying the ciphertext every time we need it, instead we cache the
verified ciphertexts in the state.

This all leads to a significant performance improvement as we can avoid
a lot of redundant ciphertext validations.