### PR TITLE
fix broken tests on OTP23

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 steps:
   - commands:
       - ". $HOME/.asdf/asdf.sh"
-      - "asdf local erlang 21.3"
+      - "asdf local erlang 23.1"
       - "make ci"
     name: ":hammer: build"
     agents:

--- a/test/hbbft_distributed_SUITE.erl
+++ b/test/hbbft_distributed_SUITE.erl
@@ -70,7 +70,7 @@ simple_test(Config) ->
                             end, Nodes),
 
     %% start a hbbft_worker on each node
-    Workers = [{Node, rpc:call(Node, hbbft_worker, start_link, [N, F, I, tpke_privkey:serialize(SK), BatchSize, false])} || {I, {Node, SK}} <- enumerate(NodesSKs)],
+    Workers = [{Node, rpc:block_call(Node, hbbft_worker, start_link, [N, F, I, tpke_privkey:serialize(SK), BatchSize, false])} || {I, {Node, SK}} <- enumerate(NodesSKs)],
     ok = global:sync(),
 
     [ link(W) || {_, {ok, W}} <- Workers ],
@@ -154,7 +154,7 @@ serialization_test(Config) ->
                             end, Nodes),
 
     %% start a hbbft_worker on each node
-    Workers = [{Node, rpc:call(Node, hbbft_worker, start_link, [N, F, I, tpke_privkey:serialize(SK), BatchSize, false])} || {I, {Node, SK}} <- enumerate(NodesSKs)],
+    Workers = [{Node, rpc:block_call(Node, hbbft_worker, start_link, [N, F, I, tpke_privkey:serialize(SK), BatchSize, false])} || {I, {Node, SK}} <- enumerate(NodesSKs)],
     ok = global:sync(),
 
     [ link(W) || {_, {ok, W}} <- Workers ],
@@ -259,7 +259,7 @@ partition_test_(Config, Filter) ->
     OtherNodes = Nodes -- [FirstNode | PartitionedNodes],
 
     %% start a hbbft_worker on each node
-    Workers = [{Node, rpc:call(Node, hbbft_worker, start_link, [N, F, I, tpke_privkey:serialize(SK), BatchSize, false])} || {I, {Node, SK}} <- enumerate(NodesSKs)],
+    Workers = [{Node, rpc:block_call(Node, hbbft_worker, start_link, [N, F, I, tpke_privkey:serialize(SK), BatchSize, false])} || {I, {Node, SK}} <- enumerate(NodesSKs)],
     ok = global:sync(),
 
     case Filter of

--- a/test/hbbft_relcast_distributed_SUITE.erl
+++ b/test/hbbft_relcast_distributed_SUITE.erl
@@ -72,11 +72,12 @@ simple_test(Config) ->
                             end, Nodes),
 
     %% start a hbbft_relcast_worker on each node
-    Workers = [{Node, ct_rpc:call(Node,
-                               hbbft_relcast_worker,
-                               start_link,
-                               [[{id, I}, {sk, tpke_privkey:serialize(SK)}, {n, N}, {f, F}, {batchsize, BatchSize}, {data_dir, DataDir}]]
-                              )} || {I, {Node, SK}} <- hbbft_test_utils:enumerate(NodesSKs)],
+    Workers = [{Node, rpc:block_call(
+                        Node,
+                        hbbft_relcast_worker,
+                        start_link,
+                        [[{id, I}, {sk, tpke_privkey:serialize(SK)}, {n, N}, {f, F}, {batchsize, BatchSize}, {data_dir, DataDir}]]
+                       )} || {I, {Node, SK}} <- hbbft_test_utils:enumerate(NodesSKs)],
     ok = global:sync(),
 
     [ link(W) || {_, {ok, W}} <- Workers ],
@@ -177,11 +178,12 @@ partition_test_(Config, Filter) ->
     ct:pal("Partitioning ~p from ~p", [FirstNode, PartitionedNodes]),
 
     %% start a hbbft_relcast_worker on each node
-    Workers = [{Node, ct_rpc:call(Node,
-                               hbbft_relcast_worker,
-                               start_link,
-                               [[{id, I}, {sk, tpke_privkey:serialize(SK)}, {n, N}, {f, F}, {batchsize, BatchSize}, {data_dir, DataDir}]]
-                              )} || {I, {Node, SK}} <- hbbft_test_utils:enumerate(NodesSKs)],
+    Workers = [{Node, rpc:block_call(
+                        Node,
+                        hbbft_relcast_worker,
+                        start_link,
+                        [[{id, I}, {sk, tpke_privkey:serialize(SK)}, {n, N}, {f, F}, {batchsize, BatchSize}, {data_dir, DataDir}]]
+                       )} || {I, {Node, SK}} <- hbbft_test_utils:enumerate(NodesSKs)],
     ok = global:sync(),
 
 


### PR DESCRIPTION
It seems that the new erpc mechanism is perhaps *too* scalable, so we make sure that it's a blocking RPC on node start to avoid some strange interactions.