### PR TITLE
Improve testing UX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ cover:
 	$(REBAR) cover
 
 test: compile
-	$(REBAR) as test do eunit,ct
+	$(REBAR) as test do dialyzer,eunit,ct
 
 typecheck:
 	$(REBAR) dialyzer

--- a/test/encode_decode_test.erl
+++ b/test/encode_decode_test.erl
@@ -11,15 +11,15 @@ encoded_decoded_equality_test() ->
     ?assert(encoded_decoded_equality_test(14, 4, crypto:strong_rand_bytes(1024))).
 
 encoded_decoded_equality_test(N, F, Msg) ->
-	%% io:format("Msg: ~p~n", [Msg]),
+	%% ct:log("Msg: ~p~n", [Msg]),
 	Threshold = N - 2*F,
-	%% io:format("Threshold: ~p~n", [Threshold]),
+	%% ct:log("Threshold: ~p~n", [Threshold]),
 	{ok, Sj} = erasure:encode(Threshold, N, Msg),
-	%% io:format("Sj: ~p~n", [Sj]),
+	%% ct:log("Sj: ~p~n", [Sj]),
 	Bits = random_n(Threshold, Sj),
-	%% io:format("Bits: ~p~n", [Bits]),
+	%% ct:log("Bits: ~p~n", [Bits]),
 	{ok, Bin} = erasure:decode(Threshold, N, Bits),
-	%% io:format("Bin: ~p~n", [Bin]),
+	%% ct:log("Bin: ~p~n", [Bin]),
 	Bin == Msg.
 
 %% helpers

--- a/test/hbbft_SUITE.erl
+++ b/test/hbbft_SUITE.erl
@@ -55,7 +55,7 @@ init_test(Config) ->
     %% feed the badgers some msgs
     lists:foreach(fun(Msg) ->
                           Destinations = random_n(rand:uniform(N), Workers),
-                          io:format("destinations ~p~n", [Destinations]),
+                          ct:log("destinations ~p~n", [Destinations]),
                           [ok = hbbft_worker:submit_transaction(Msg, D) || D <- Destinations]
                   end, Msgs),
 
@@ -67,7 +67,7 @@ init_test(Config) ->
 
     1 = sets:size(Chains),
     [Chain] = sets:to_list(Chains),
-    io:format("chain is of height ~p~n", [length(Chain)]),
+    ct:log("chain is of height ~p~n", [length(Chain)]),
     %% verify they are cryptographically linked
     true = hbbft_worker:verify_chain(Chain, PubKey),
     %% check all the transactions are unique
@@ -75,7 +75,7 @@ init_test(Config) ->
     true = length(BlockTxns) == sets:size(sets:from_list(BlockTxns)),
     %% check they're all members of the original message list
     true = sets:is_subset(sets:from_list(BlockTxns), sets:from_list(Msgs)),
-    io:format("chain contains ~p distinct transactions~n", [length(BlockTxns)]),
+    ct:log("chain contains ~p distinct transactions~n", [length(BlockTxns)]),
     ok.
 
 one_actor_no_txns_test(Config) ->
@@ -229,7 +229,7 @@ start_on_demand_test(Config) ->
     %% feed the badgers some msgs
     lists:foreach(fun(Msg) ->
                           Destinations = random_n(rand:uniform(length(RemainingWorkers)), RemainingWorkers),
-                          io:format("destinations ~p~n", [Destinations]),
+                          ct:log("destinations ~p~n", [Destinations]),
                           [ok = hbbft_worker:submit_transaction(Msg, D) || D <- Destinations]
                   end, Msgs),
 
@@ -245,7 +245,7 @@ start_on_demand_test(Config) ->
 
     1 = sets:size(Chains),
     [Chain] = sets:to_list(Chains),
-    io:format("chain is of height ~p~n", [length(Chain)]),
+    ct:log("chain is of height ~p~n", [length(Chain)]),
     %% verify they are cryptographically linked
     true = hbbft_worker:verify_chain(Chain, PubKey),
     %% check all the transactions are unique
@@ -254,7 +254,7 @@ start_on_demand_test(Config) ->
     true = length(BlockTxns) == sets:size(sets:from_list(BlockTxns)),
     %% check they're all members of the original message list
     true = sets:is_subset(sets:from_list(BlockTxns), sets:from_list([KnownMsg | Msgs])),
-    io:format("chain contains ~p distinct transactions~n", [length(BlockTxns)]),
+    ct:log("chain contains ~p distinct transactions~n", [length(BlockTxns)]),
     ok.
 
 one_actor_wrong_key_test(Config) ->
@@ -275,7 +275,7 @@ one_actor_wrong_key_test(Config) ->
     %% feed the badgers some msgs
     lists:foreach(fun(Msg) ->
                           Destinations = random_n(rand:uniform(N), Workers),
-                          io:format("destinations ~p~n", [Destinations]),
+                          ct:log("destinations ~p~n", [Destinations]),
                           [ok = hbbft_worker:submit_transaction(Msg, D) || D <- Destinations]
                   end, Msgs),
 
@@ -289,7 +289,7 @@ one_actor_wrong_key_test(Config) ->
 
     1 = sets:size(Chains),
     [Chain] = sets:to_list(Chains),
-    io:format("chain is of height ~p~n", [length(Chain)]),
+    ct:log("chain is of height ~p~n", [length(Chain)]),
     %% verify they are cryptographically linked
     true = hbbft_worker:verify_chain(lists:reverse(Chain), PubKey),
     %% check all the transactions are unique
@@ -297,7 +297,7 @@ one_actor_wrong_key_test(Config) ->
     true = length(BlockTxns) == sets:size(sets:from_list(BlockTxns)),
     %% check they're all members of the original message list
     true = sets:is_subset(sets:from_list(BlockTxns), sets:from_list(Msgs)),
-    io:format("chain contains ~p distinct transactions~n", [length(BlockTxns)]),
+    ct:log("chain contains ~p distinct transactions~n", [length(BlockTxns)]),
     ok = Result,
     ok.
 
@@ -320,7 +320,7 @@ one_actor_corrupted_key_test(Config) ->
     %% feed the badgers some msgs
     lists:foreach(fun(Msg) ->
                           Destinations = random_n(rand:uniform(N), Workers),
-                          io:format("destinations ~p~n", [Destinations]),
+                          ct:log("destinations ~p~n", [Destinations]),
                           [ok = hbbft_worker:submit_transaction(Msg, D) || D <- Destinations]
                   end, Msgs),
 
@@ -332,7 +332,7 @@ one_actor_corrupted_key_test(Config) ->
 
     1 = sets:size(Chains),
     [Chain] = sets:to_list(Chains),
-    io:format("chain is of height ~p~n", [length(Chain)]),
+    ct:log("chain is of height ~p~n", [length(Chain)]),
     %% verify they are cryptographically linked
     true = hbbft_worker:verify_chain(Chain, PubKey),
     %% check all the transactions are unique
@@ -340,7 +340,7 @@ one_actor_corrupted_key_test(Config) ->
     true = length(BlockTxns) == sets:size(sets:from_list(BlockTxns)),
     %% check they're all members of the original message list
     true = sets:is_subset(sets:from_list(BlockTxns), sets:from_list(Msgs)),
-    io:format("chain contains ~p distinct transactions~n", [length(BlockTxns)]),
+    ct:log("chain contains ~p distinct transactions~n", [length(BlockTxns)]),
     ok.
 
 

--- a/test/hbbft_acs_SUITE.erl
+++ b/test/hbbft_acs_SUITE.erl
@@ -31,7 +31,7 @@ end_per_suite(_Config) ->
 
 init_per_testcase(_, Config) ->
     eprof:start_profiling([self()]),
-    N = list_to_integer(os:getenv("N", "34")),
+    N = list_to_integer(os:getenv("N", "10")), % N > 25 runs for minutes.
     F = N div 4,
     Module = hbbft_acs,
     {ok, Dealer} = dealer:new(N, F+1, 'SS512'),

--- a/test/hbbft_acs_SUITE.erl
+++ b/test/hbbft_acs_SUITE.erl
@@ -4,7 +4,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("relcast/include/fakecast.hrl").
 
--export([all/0, init_per_testcase/2, end_per_testcase/2]).
+-export([all/0, init_per_suite/1, end_per_suite/1, init_per_testcase/2, end_per_testcase/2]).
 -export([
          init_test/1,
          one_dead_test/1,
@@ -22,7 +22,15 @@ all() ->
      fakecast_test
     ].
 
+init_per_suite(Config) ->
+    {ok, _} = eprof:start(),
+    Config.
+
+end_per_suite(_Config) ->
+  ok.
+
 init_per_testcase(_, Config) ->
+    eprof:start_profiling([self()]),
     N = list_to_integer(os:getenv("N", "34")),
     F = N div 4,
     Module = hbbft_acs,
@@ -31,6 +39,8 @@ init_per_testcase(_, Config) ->
     [{n, N}, {f, F}, {module, Module}, {privatekeys, PrivateKeys} | Config].
 
 end_per_testcase(_, _Config) ->
+    eprof:stop_profiling(),
+    eprof:analyze(total),
     ok.
 
 init_test(Config) ->

--- a/test/hbbft_rbc_worker.erl
+++ b/test/hbbft_rbc_worker.erl
@@ -26,13 +26,13 @@ get_results(Pid) ->
 
 init([N, F, Id, Leader]) ->
     RBC = hbbft_rbc:init(N, F, Id, Leader),
-    io:format("RBC: ~p~n", [RBC]),
+    ct:log("RBC: ~p~n", [RBC]),
     {ok, #state{rbc=RBC, n=N, id=Id, leader=Leader}}.
 
 handle_call(get_results, _From, State) ->
     {reply, State#state.result, State};
 handle_call(Msg, _from, State) ->
-    io:format("unhandled msg ~p~n", [Msg]),
+    ct:log("unhandled msg ~p~n", [Msg]),
     {reply, ok, State}.
 
 
@@ -43,11 +43,11 @@ handle_cast({rbc, PeerID, Msg}, State = #state{rbc=RBC}) ->
     NewState = dispatch(hbbft_rbc:handle_msg(RBC, PeerID, Msg), State),
     {noreply, NewState};
 handle_cast(Msg, State) ->
-    io:format("unhandled msg ~p~n", [Msg]),
+    ct:log("unhandled msg ~p~n", [Msg]),
     {noreply, State}.
 
 handle_info(Msg, State) ->
-    io:format("unhandled msg ~p~n", [Msg]),
+    ct:log("unhandled msg ~p~n", [Msg]),
     {noreply, State}.
 
 
@@ -70,10 +70,10 @@ dispatch({NewRBC, {result, Result}}, State) ->
 dispatch({NewRBC, ok}, State) ->
     State#state{rbc=NewRBC};
 dispatch({NewRBC, Other}, State) ->
-    io:format("UNHANDLED ~p~n", [Other]),
+    ct:log("UNHANDLED ~p~n", [Other]),
     State#state{rbc=NewRBC};
 dispatch(Other, State) ->
-    io:format("UNHANDLED2 ~p~n", [Other]),
+    ct:log("UNHANDLED2 ~p~n", [Other]),
     State.
 
 name(X) ->

--- a/test/hbbft_relcast_SUITE.erl
+++ b/test/hbbft_relcast_SUITE.erl
@@ -271,7 +271,7 @@ start_on_demand_test(Config) ->
     %% feed the badgers some msgs
     lists:foreach(fun(Msg) ->
                           Destinations = hbbft_test_utils:random_n(rand:uniform(length(RemainingWorkers)), RemainingWorkers),
-                          io:format("destinations ~p~n", [Destinations]),
+                          ct:log("destinations ~p~n", [Destinations]),
                           [ok = hbbft_relcast_worker:submit_transaction(Msg, D) || D <- Destinations]
                   end, Msgs),
 
@@ -310,7 +310,7 @@ start_on_demand_test(Config) ->
                                       end, Workers)),
     1 = sets:size(Chains),
     [Chain] = sets:to_list(Chains),
-    io:format("chain is of height ~p~n", [length(Chain)]),
+    ct:log("chain is of height ~p~n", [length(Chain)]),
     %% verify they are cryptographically linked
     true = hbbft_relcast_worker:verify_chain(Chain, PubKey),
     %% check all the transactions are unique
@@ -319,7 +319,7 @@ start_on_demand_test(Config) ->
     true = length(BlockTxns) == sets:size(sets:from_list(BlockTxns)),
     %% check they're all members of the original message list
     true = sets:is_subset(sets:from_list(BlockTxns), sets:from_list([KnownMsg | Msgs])),
-    io:format("chain contains ~p distinct transactions~n", [length(BlockTxns)]),
+    ct:log("chain contains ~p distinct transactions~n", [length(BlockTxns)]),
     [gen_server:stop(W) || W <- Workers],
     ok.
 

--- a/test/hbbft_test_utils.erl
+++ b/test/hbbft_test_utils.erl
@@ -2,6 +2,13 @@
 
 -export([do_send_outer/4, shuffle/1, random_n/2, enumerate/1, merge_replies/3]).
 
+% TODO Type of Acc elements
+% TODO Type of States elements
+% TODO Type of Results elements
+-spec do_send_outer(Module :: atom(), Results :: list(), States, Acc) ->
+    {States, Acc}
+      when Acc :: sets:set(tuple()),
+           States :: list().
 do_send_outer(_Mod, [], States, Acc) ->
     {States, Acc};
 do_send_outer(Mod, [{result, {Id, Result}} | T], Pids, Acc) ->


### PR DESCRIPTION
TL;DR: ACS suite is slow because N is high.

NTL;R: Profiled the test suite and found that:
1. ACS suite takes the longest
2. in ACS suite two tests take the longest:
  - `init_test`
  - `one_dead_test`
3. in the above two tests, most time is spent in `do_send_outer`
4. overall most time is spent doing list appends
5. then, the main difference between ACS and other suites is the magnitude
   of default `N`, whereas ACS defaults to 34, others use a lower value
6. finally, decreasing ACS's N to <20 - dramatically speeds-up execution:

```sh
$ for n in $(seq 5 5 35); do printf "N=%d => " "$n"; time N="$n" ./rebar3 ct --suite hbbft_acs_SUITE > /dev/null; done
N=5 => N="$n" ./rebar3 ct --suite hbbft_acs_SUITE > /dev/null  3.38s user 0.51s system 107% cpu 3.611 total
N=10 => N="$n" ./rebar3 ct --suite hbbft_acs_SUITE > /dev/null  3.94s user 0.61s system 111% cpu 4.077 total
N=15 => N="$n" ./rebar3 ct --suite hbbft_acs_SUITE > /dev/null  5.14s user 0.72s system 109% cpu 5.335 total
N=20 => N="$n" ./rebar3 ct --suite hbbft_acs_SUITE > /dev/null  9.78s user 0.85s system 122% cpu 8.677 total
N=25 => N="$n" ./rebar3 ct --suite hbbft_acs_SUITE > /dev/null  22.26s user 1.30s system 149% cpu 15.761 total
N=30 => N="$n" ./rebar3 ct --suite hbbft_acs_SUITE > /dev/null  152.79s user 19.09s system 148% cpu 1:55.58 total
N=35 => N="$n" ./rebar3 ct --suite hbbft_acs_SUITE > /dev/null  514.02s user 57.72s system 134% cpu 7:06.10 total
```

In the long-run we should probably revisit implementation of `do_send_outer`.