### PR TITLE
Bump erasure

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -1,7 +1,7 @@
 {"1.1.0",
 [{<<"erasure">>,
   {git,"https://github.com/helium/erlang-erasure.git",
-       {ref,"f8f9a80bbbe335f67b0f9b65dc8ebde72a1788e7"}},
+       {ref,"c73354ca9914225a825569693dc72db6691d91f1"}},
   0},
  {<<"erlang_pbc">>,
   {git,"https://github.com/helium/erlang_pbc.git",


### PR DESCRIPTION
This PR bumps the erasure dependency to [improve] (1) cross-compilation for (but not limited to) OpenWRT.

[improve]: https://github.com/helium/erlang-erasure/pull/12
1: this includes a hot patch that wasn't caught in the original erasure PR: https://github.com/helium/erlang-erasure/commit/c73354ca9914225a825569693dc72db6691d91f1